### PR TITLE
feat: remove bluegreen strategy from deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,6 @@ kill_signal = 'SIGTERM'
 [build]
 
 [deploy]
-  strategy = 'bluegreen'
   release_command = '/app/bin/migrate'
 
 [http_service]


### PR DESCRIPTION
- eliminated `strategy = 'bluegreen'` from `fly.toml`
- simplifies deployment configuration for easier management
- prepares for a more streamlined release process